### PR TITLE
Use jupyter scipy notebook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,0 @@
-FROM jupyter/scipy-notebook:latest
-MAINTAINER dan.leehr@duke.edu
-USER root
-RUN apt-get update && apt-get install -y texlive-xetex
-USER $NB_USER

--- a/cleanup-tmpnb.sh
+++ b/cleanup-tmpnb.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export NOTEBOOK_IMAGE="dukegcb/scipy-notebook"
+export NOTEBOOK_IMAGE="jupyter/scipy-notebook"
 
 # Clear out any existing containers
 docker rm -f proxy tmpnb 2> /dev/null

--- a/cleanup-tmpnb.sh
+++ b/cleanup-tmpnb.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+export NOTEBOOK_IMAGE="dukegcb/scipy-notebook"
+
+# Clear out any existing containers
+docker rm -f proxy tmpnb 2> /dev/null
+OLD_NOTEBOOKS=$(docker ps --filter=ancestor=${NOTEBOOK_IMAGE} -a -q)
+if [ "$OLD_NOTEBOOKS" ]; then
+  docker rm -f $OLD_NOTEBOOKS
+fi

--- a/run-tmpnb.sh
+++ b/run-tmpnb.sh
@@ -11,8 +11,7 @@ fi
 
 NOTEBOOK_PASSWORD=$1 # The password users will have to provide to access a notebook
 
-# Can use "jupyter/scipy-notebook" once they merge https://github.com/jupyter/docker-stacks/issues/353
-export NOTEBOOK_IMAGE="dukegcb/scipy-notebook"
+export NOTEBOOK_IMAGE="jupyter/scipy-notebook"
 export EXTERNAL_PORT="8000"
 
 export INTERNAL_PORT=$(($EXTERNAL_PORT+1))

--- a/run-tmpnb.sh
+++ b/run-tmpnb.sh
@@ -50,5 +50,3 @@ docker run \
   --name=tmpnb \
   -v /var/run/docker.sock:/docker.sock \
   jupyter/tmpnb python orchestrate.py --image=$NOTEBOOK_IMAGE --command='start-notebook.sh "--NotebookApp.base_url={base_path} --ip=0.0.0.0 --port={port} --NotebookApp.trust_xheaders=True" --NotebookApp.token='"${NOTEBOOK_PASSWORD}"
-
-exit 0


### PR DESCRIPTION
The jupyter/scipy-notebook image has been updated to include the necessary package for pdf conversion, so we no longer need our own custom docker image.